### PR TITLE
fix: Avoid NPE when uuid is null

### DIFF
--- a/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/model/reference/Outcome.java
+++ b/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/model/reference/Outcome.java
@@ -141,7 +141,7 @@ public class Outcome implements Serializable {
   public String toString() {
     return "Reason{" +
         "id=" + id +
-        ", uuid='" + uuid.toString() + '\'' +
+        ", uuid='" + uuid + '\'' +
         ", code='" + code + '\'' +
         ", label='" + label + '\'' +
         '}';

--- a/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/model/reference/Reason.java
+++ b/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/model/reference/Reason.java
@@ -153,7 +153,7 @@ public class Reason implements Serializable {
   public String toString() {
     return "Reason{" +
         "id=" + id +
-        ", uuid='" + uuid.toString() + '\'' +
+        ", uuid='" + uuid + '\'' +
         ", code='" + code + '\'' +
         ", label='" + label + '\'' +
         ", outcomes=" + outcomes +


### PR DESCRIPTION
As per https://github.com/Health-Education-England/TIS-REFERENCE/commit/d1f2c392bf328287157686e8f2bfcaa84d11f9c8

When the UUID is null calling the `toString()` method of the DTO causes
a NPE, remove the explicit `toString()` call from the `uuid` field.

TISNEW-5757