### PR TITLE
fix: enable healthchecks in prod

### DIFF
--- a/assessments-service/src/main/resources/config/application-prod.yml
+++ b/assessments-service/src/main/resources/config/application-prod.yml
@@ -68,3 +68,5 @@ application:
 
 endpoints:
   enabled: false # disable all endpoints
+  health:
+    enabled: true # except for healthchecks


### PR DESCRIPTION
The prod environment overrides which healthchecks are available.
This change enables the health endpoint only.