### PR TITLE
chore: use main branch from utils library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('utils@master') _
+@Library('utils@main') _
 
 def utils = new hee.tis.utils()
 


### PR DESCRIPTION
The utils library is found in TIS-JENKINS, change the reference to the
`main` branch instead of `master`

TIS21-2345