### PR TITLE
chore(deps): bump tis-parent-client from 4.2.1 to 5.1.4

### DIFF
--- a/assessments-client/pom.xml
+++ b/assessments-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>assessments-client</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>tis-parent-client</artifactId>
-      <version>4.1.2</version>
+      <version>5.1.4</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>

--- a/assessments-service/pom.xml
+++ b/assessments-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>assessments-service</artifactId>
-  <version>1.14.0</version>
+  <version>1.14.1</version>
   <packaging>war</packaging>
 
   <properties>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>tis-parent-client</artifactId>
-      <version>4.1.2</version>
+      <version>5.1.4</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>


### PR DESCRIPTION
Bump the version of `tis-parent-client` to `5.1.4` to update transient
dependency `tis-security-jwt` to `5.1.4`, which allows usage with
Cognito/AWS API Gateway.

TIS21-2477, TIS21-2474