### PR TITLE
chore(deps): use patched assessments api

### DIFF
--- a/assessments-client/pom.xml
+++ b/assessments-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>assessments-client</artifactId>
-  <version>1.2.2</version>
+  <version>1.2.3</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>assessments-api</artifactId>
-      <version>1.5.2</version>
+      <version>1.5.3</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>


### PR DESCRIPTION
At the moment the vulnerability is still used by the latest version.