### PR TITLE
fix: patch assessments for bulk upload

### DIFF
--- a/assessments-service/pom.xml
+++ b/assessments-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>assessments-service</artifactId>
-  <version>1.14.2</version>
+  <version>1.14.3</version>
   <packaging>war</packaging>
 
   <properties>

--- a/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImpl.java
+++ b/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImpl.java
@@ -293,33 +293,21 @@ public class AssessmentServiceImpl implements AssessmentService {
     RevalidationDTO revalidationDto = null;
 
     if (assessmentDto.getDetail() != null) {
-      if (assessmentDto.getDetail().getId() != null) {
-        assessmentDetailDto = assessmentDetailService.save(assessment,
-            assessmentDto.getDetail());
-      } else {
-        assessmentDetailDto = assessmentDetailService.create(assessment,
-            assessmentDto.getDetail());
-      }
+      assessmentDetailDto = assessmentDto.getDetail().getId() != null
+          ? assessmentDetailService.save(assessment, assessmentDto.getDetail())
+          : assessmentDetailService.create(assessment, assessmentDto.getDetail());
     }
 
     if (assessmentDto.getOutcome() != null) {
-      if (assessmentDto.getOutcome().getId() != null) {
-        assessmentOutcomeDto =
-            assessmentOutcomeService.save(assessment, assessmentDto.getOutcome());
-      } else {
-        assessmentOutcomeDto =
-            assessmentOutcomeService.create(assessment, assessmentDto.getOutcome());
-      }
+      assessmentOutcomeDto = assessmentDto.getOutcome().getId() != null
+          ? assessmentOutcomeService.save(assessment, assessmentDto.getOutcome())
+          : assessmentOutcomeService.create(assessment, assessmentDto.getOutcome());
     }
 
     if (assessmentDto.getRevalidation() != null) {
-      if (assessmentDto.getRevalidation().getId() != null) {
-        revalidationDto =
-            revalidationService.save(assessment, assessmentDto.getRevalidation());
-      } else {
-        revalidationDto =
-            revalidationService.create(assessment, assessmentDto.getRevalidation());
-      }
+      revalidationDto = assessmentDto.getRevalidation().getId() != null
+          ? revalidationService.save(assessment, assessmentDto.getRevalidation())
+          : revalidationService.create(assessment, assessmentDto.getRevalidation());
     }
 
     AssessmentDTO savedAssessmentDto = save(assessmentDto);

--- a/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImpl.java
+++ b/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImpl.java
@@ -286,6 +286,49 @@ public class AssessmentServiceImpl implements AssessmentService {
     return false;
   }
 
+  private AssessmentDTO updateAssessmentWithNestedDtos(AssessmentDTO assessmentDto) {
+    Assessment assessment = assessmentMapper.toEntity(assessmentDto);
+    AssessmentDetailDTO assessmentDetailDto = null;
+    AssessmentOutcomeDTO assessmentOutcomeDto = null;
+    RevalidationDTO revalidationDto = null;
+
+    if (assessmentDto.getDetail() != null) {
+      if (assessmentDto.getDetail().getId() != null) {
+        assessmentDetailDto = assessmentDetailService.save(assessment,
+            assessmentDto.getDetail());
+      } else {
+        assessmentDetailDto = assessmentDetailService.create(assessment,
+            assessmentDto.getDetail());
+      }
+    }
+
+    if (assessmentDto.getOutcome() != null) {
+      if (assessmentDto.getOutcome().getId() != null) {
+        assessmentOutcomeDto =
+            assessmentOutcomeService.save(assessment, assessmentDto.getOutcome());
+      } else {
+        assessmentOutcomeDto =
+            assessmentOutcomeService.create(assessment, assessmentDto.getOutcome());
+      }
+    }
+
+    if (assessmentDto.getRevalidation() != null) {
+      if (assessmentDto.getRevalidation().getId() != null) {
+        revalidationDto =
+            revalidationService.save(assessment, assessmentDto.getRevalidation());
+      } else {
+        revalidationDto =
+            revalidationService.create(assessment, assessmentDto.getRevalidation());
+      }
+    }
+
+    AssessmentDTO savedAssessmentDto = save(assessmentDto);
+    savedAssessmentDto.setDetail(assessmentDetailDto);
+    savedAssessmentDto.setOutcome(assessmentOutcomeDto);
+    savedAssessmentDto.setRevalidation(revalidationDto);
+    return savedAssessmentDto;
+  }
+
   @Override
   @Transactional
   public List<AssessmentDTO> patchAssessments(List<AssessmentDTO> assessmentDtos) {
@@ -297,28 +340,7 @@ public class AssessmentServiceImpl implements AssessmentService {
     AssessmentDTO returnDto = null;
     for (AssessmentDTO assessmentDto : assessmentDtos) {
       try {
-        Assessment assessment = assessmentMapper.toEntity(assessmentDto);
-        AssessmentDetailDTO assessmentDetailDto = null;
-        AssessmentOutcomeDTO assessmentOutcomeDto = null;
-        RevalidationDTO revalidationDto = null;
-        if (assessmentDto.getDetail() != null && assessmentDto.getDetail().getId() != null) {
-          assessmentDetailDto =
-              assessmentDetailService.save(assessment, assessmentDto.getDetail());
-        }
-        if (assessmentDto.getOutcome() != null && assessmentDto.getOutcome().getId() != null) {
-          assessmentOutcomeDto =
-              assessmentOutcomeService.save(assessment, assessmentDto.getOutcome());
-        }
-        if (assessmentDto.getRevalidation() != null
-            && assessmentDto.getRevalidation().getId() != null) {
-          revalidationDto =
-              revalidationService.save(assessment, assessmentDto.getRevalidation());
-        }
-        AssessmentDTO savedAssessmentDto = save(assessmentDto);
-        savedAssessmentDto.setDetail(assessmentDetailDto);
-        savedAssessmentDto.setOutcome(assessmentOutcomeDto);
-        savedAssessmentDto.setRevalidation(revalidationDto);
-        returnDto = savedAssessmentDto;
+        returnDto = updateAssessmentWithNestedDtos(assessmentDto);
       } catch (Exception e) {
         returnDto = assessmentDto;
         returnDto.addMessage(String.format(ASSESSMENT_UPDATE_FAILED, assessmentDto.getId()));

--- a/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/api/AssessmentResourceIntTest.java
+++ b/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/api/AssessmentResourceIntTest.java
@@ -611,7 +611,6 @@ public class AssessmentResourceIntTest {
   public void bulkUpdateAssessmentShouldCreateNestedDTOsWhenIdIsNull() throws Exception {
     // Initialize the database
     assessment = new Assessment()
-        .id(DEFAULT_ID)
         .traineeId(DEFAULT_PERSON_ID)
         .firstName(DEFAULT_FIRST_NAME)
         .lastName(DEFAULT_LAST_NAME)
@@ -627,9 +626,10 @@ public class AssessmentResourceIntTest {
         .softDeletedDate(null);
     assessmentRepository.saveAndFlush(assessment);
     int databaseSizeBeforeUpdate = assessmentRepository.findAll().size();
+    Long assessmentId = assessment.getId();
 
     // Update the assessment
-    Assessment updatedAssessment = assessmentRepository.findOne(assessment.getId());
+    Assessment updatedAssessment = assessmentRepository.findOne(assessmentId);
     updatedAssessment
         .reviewDate(UPDATED_START_DATE)
         .programmeNumber(UPDATED_PROGRAMME_NUMBER)
@@ -656,22 +656,22 @@ public class AssessmentResourceIntTest {
     // Validate the Assessment in the database
     List<Assessment> assessmentList = assessmentRepository.findAll();
     assertThat(assessmentList).hasSize(databaseSizeBeforeUpdate);
-    Assessment testAssessment = assessmentRepository.findOne(DEFAULT_ID);
+    Assessment testAssessment = assessmentRepository.findOne(assessmentId);
 
     assertThat(testAssessment.getId()).isEqualTo(updatedAssessment.getId());
     assertThat(testAssessment.getProgrammeName()).isEqualTo(UPDATED_PROGRAMME_NAME);
     assertThat(testAssessment.getProgrammeNumber()).isEqualTo(UPDATED_PROGRAMME_NUMBER);
 
     assertThat(testAssessment.getDetail()).isNotNull();
-    assertThat(testAssessment.getDetail().getId()).isEqualTo(DEFAULT_ID);
+    assertThat(testAssessment.getDetail().getId()).isEqualTo(assessmentId);
     assertThat(testAssessment.getDetail().getCurriculumId()).isEqualTo(DEFAULT_CURRICULUM_ID);
 
     assertThat(testAssessment.getOutcome()).isNotNull();
-    assertThat(testAssessment.getOutcome().getId()).isEqualTo(DEFAULT_ID);
+    assertThat(testAssessment.getOutcome().getId()).isEqualTo(assessmentId);
     assertThat(testAssessment.getOutcome().getOutcome()).isEqualTo(DEFAULT_OUTCOME);
 
     assertThat(testAssessment.getRevalidation()).isNotNull();
-    assertThat(testAssessment.getRevalidation().getId()).isEqualTo(DEFAULT_ID);
+    assertThat(testAssessment.getRevalidation().getId()).isEqualTo(assessmentId);
     assertThat(testAssessment.getRevalidation().getKnownConcerns())
         .isEqualTo(DEFAULT_KNOWN_CONCERNS);
   }

--- a/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImplTest.java
+++ b/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImplTest.java
@@ -652,4 +652,27 @@ public class AssessmentServiceImplTest {
     Assert.assertEquals(assessmentDto, result.get(0));
     Assert.assertEquals(1, assessmentDto.getMessageList().size());
   }
+
+  @Test
+  public void patchAssessmentShouldCreateNestedDTOsWhenIdIsNull() {
+    AssessmentDTO assessmentDto = new AssessmentDTO();
+    AssessmentDetailDTO assessmentDetailDto = new AssessmentDetailDTO();
+    AssessmentOutcomeDTO assessmentOutcomeDto = new AssessmentOutcomeDTO();
+    RevalidationDTO revalidationDto = new RevalidationDTO();
+    assessmentDetailDto.curriculumName("curriculumName");
+    assessmentOutcomeDto.outcome("1");
+    revalidationDto.knownConcerns(Boolean.FALSE);
+    assessmentDto.id(ASSESSMENT_ID).detail(assessmentDetailDto).outcome(assessmentOutcomeDto)
+        .revalidation(revalidationDto);
+
+    List<AssessmentDTO> assessmentDtos = Collections.singletonList(assessmentDto);
+
+    AssessmentDTO result = testObj.patchAssessments(assessmentDtos).get(0);
+
+    verify(assessmentDetailServiceMock).create(any(Assessment.class),
+        any(AssessmentDetailDTO.class));
+    verify(assessmentOutcomeServiceMock).create(any(Assessment.class),
+        any(AssessmentOutcomeDTO.class));
+    verify(revalidationServiceMock).create(any(Assessment.class), any(RevalidationDTO.class));
+  }
 }


### PR DESCRIPTION
When bulk update Assessments, if nested AssessmentDetailsDTO, AssessmentOutcomDTO or RevalidationDTO has a null ID, should create a new DTO for them.

TIS21-3234