### PR TITLE
fix:upload_build_artifact in ci-cd-workflow

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: app-jar
-          path: assessments-*/target/*.war
+          path: assessments-*/target/*.jar
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
Found the assessment-client doesn't get uploaded onto code artifact.

no-ticket