### PR TITLE
fix: add distributionManagement in pom

### DIFF
--- a/assessments-api/pom.xml
+++ b/assessments-api/pom.xml
@@ -76,4 +76,12 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>codeartifact</id>
+      <name>CodeArtifact</name>
+      <url>https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/assessments-client/pom.xml
+++ b/assessments-client/pom.xml
@@ -65,4 +65,12 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>codeartifact</id>
+      <name>CodeArtifact</name>
+      <url>https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/</url>
+    </repository>
+  </distributionManagement>
 </project>


### PR DESCRIPTION
to specify the remote repositories

The last PR only fixed uploading artifact to s3 bucket, but uploading the dependencies to CodeArtifact still fails:
![image](https://user-images.githubusercontent.com/33690649/184118282-e47a653a-e2be-4193-a0c3-c2e9ac43c816.png)

no-ticket