### PR TITLE
chore:config java version to 17 for Sonar analysis

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: maven
           distribution: temurin
@@ -60,10 +60,10 @@ jobs:
         run: mvn test
 
       - name: Set up analysis JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: maven
-          distribution: adopt
+          distribution: temurin
           java-version: 17
 
       - name: maven-settings-xml-action
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: maven
           distribution: temurin

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -59,6 +59,19 @@ jobs:
       - name: Run tests
         run: mvn test
 
+      - name: Set up analysis JDK
+        uses: actions/setup-java@v3
+        with:
+          cache: maven
+          distribution: adopt
+          java-version: 17
+
+      - name: maven-settings-xml-action
+        uses: whelk-io/maven-settings-xml-action@v21
+        with:
+          servers: '[{ "id": "codeartifact", "username": "aws", "password": "${env.CODEARTIFACT_AUTH_TOKEN}" }]'
+          repositories: '[{ "id": "codeartifact", "url": "https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/" }]'
+
       - name: Run quality analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After the PR: https://github.com/Health-Education-England/TIS-ASSESSMENTS/pull/141 was merged, I got the below error in the pipeline: 

```
Error:  Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar (default-cli) on project assessments: Execution default-cli of goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar failed: An API incompatibility was encountered while executing org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar: java.lang.UnsupportedClassVersionError: org/sonar/batch/bootstrapper/EnvironmentInformation has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```
https://github.com/Health-Education-England/TIS-ASSESSMENTS/actions/runs/11049466545/job/30695075275

TIS21-6496