### PR TITLE
fix:assessmentUpdate remove transactional and optimise error message

### DIFF
--- a/assessments-service/pom.xml
+++ b/assessments-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>assessments-service</artifactId>
-  <version>1.16.0</version>
+  <version>1.16.1</version>
   <packaging>war</packaging>
 
   <properties>

--- a/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/service/AssessmentService.java
+++ b/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/service/AssessmentService.java
@@ -98,4 +98,12 @@ public interface AssessmentService {
    * @return saved assessmentDTO list
    */
   List<AssessmentDTO> patchAssessments(List<AssessmentDTO> assessmentDtos);
+
+  /**
+   * Update an AssessmentDto with nested dtos.
+   *
+   * @param assessmentDto the assessmentDto to update
+   * @return updated assessmentDto
+   */
+  AssessmentDTO updateAssessmentWithNestedDtos(AssessmentDTO assessmentDto);
 }

--- a/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImpl.java
+++ b/assessments-service/src/main/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImpl.java
@@ -28,7 +28,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -66,13 +66,13 @@ public class AssessmentServiceImpl implements AssessmentService {
 
   private RevalidationService revalidationService;
 
-  @Autowired
   private AssessmentService assessmentService;
 
   AssessmentServiceImpl(AssessmentRepository assessmentRepository,
       AssessmentMapper assessmentMapper, AssessmentListMapper assessmentListMapper,
       PermissionService permissionService, AssessmentDetailService assessmentDetailService,
-      AssessmentOutcomeService assessmentOutcomeService, RevalidationService revalidationService) {
+      AssessmentOutcomeService assessmentOutcomeService, RevalidationService revalidationService,
+      @Lazy AssessmentService assessmentService) {
     this.assessmentRepository = assessmentRepository;
     this.assessmentMapper = assessmentMapper;
     this.assessmentListMapper = assessmentListMapper;
@@ -80,6 +80,7 @@ public class AssessmentServiceImpl implements AssessmentService {
     this.assessmentDetailService = assessmentDetailService;
     this.assessmentOutcomeService = assessmentOutcomeService;
     this.revalidationService = revalidationService;
+    this.assessmentService = assessmentService;
   }
 
   /**
@@ -323,7 +324,7 @@ public class AssessmentServiceImpl implements AssessmentService {
           : revalidationService.create(assessment, assessmentDto.getRevalidation());
     }
 
-    AssessmentDTO savedAssessmentDto = save(assessmentDto);
+    AssessmentDTO savedAssessmentDto = assessmentService.save(assessmentDto);
     savedAssessmentDto.setDetail(assessmentDetailDto);
     savedAssessmentDto.setOutcome(assessmentOutcomeDto);
     savedAssessmentDto.setRevalidation(revalidationDto);

--- a/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImplTest.java
+++ b/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImplTest.java
@@ -107,6 +107,8 @@ public class AssessmentServiceImplTest {
     testObj = new AssessmentServiceImpl(assessmentRepositoryMock, assessmentMapper,
         new AssessmentListMapperImpl(), permissionServiceMock, assessmentDetailServiceMock,
         assessmentOutcomeServiceMock, revalidationServiceMock);
+
+    ReflectionTestUtils.setField(testObj, "assessmentService", testObj);
   }
 
   @Test

--- a/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImplTest.java
+++ b/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImplTest.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.assertj.core.util.Lists;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -415,12 +414,12 @@ public class AssessmentServiceImplTest {
     boolean result = testObj.deleteTraineeAssessment(ASSESSMENT_ID, TRAINEE_ID);
 
     verify(assessmentRepositoryMock, never()).delete(anyLong());
-    Assert.assertFalse(result);
+    assertFalse(result);
 
     Example<Assessment> capturedExample = assessmentCaptor.getValue();
     Assessment probe = capturedExample.getProbe();
-    Assert.assertEquals(ASSESSMENT_ID, probe.getId());
-    Assert.assertEquals(TRAINEE_ID, probe.getTraineeId());
+    assertEquals(ASSESSMENT_ID, probe.getId());
+    assertEquals(TRAINEE_ID, probe.getTraineeId());
   }
 
   @Test
@@ -434,12 +433,12 @@ public class AssessmentServiceImplTest {
     boolean result = testObj.deleteTraineeAssessment(ASSESSMENT_ID, TRAINEE_ID);
 
     verify(assessmentRepositoryMock).delete(assessment);
-    Assert.assertTrue(result);
+    assertTrue(result);
 
     Example<Assessment> capturedExample = assessmentCaptor.getValue();
     Assessment probe = capturedExample.getProbe();
-    Assert.assertEquals(ASSESSMENT_ID, probe.getId());
-    Assert.assertEquals(TRAINEE_ID, probe.getTraineeId());
+    assertEquals(ASSESSMENT_ID, probe.getId());
+    assertEquals(TRAINEE_ID, probe.getTraineeId());
   }
 
   @Test(expected = NullPointerException.class)
@@ -455,7 +454,7 @@ public class AssessmentServiceImplTest {
     boolean result = testObj.deleteAssessment(ASSESSMENT_ID);
 
     verify(assessmentRepositoryMock, never()).delete(anyLong());
-    Assert.assertFalse(result);
+    assertFalse(result);
   }
 
   @Test
@@ -468,7 +467,7 @@ public class AssessmentServiceImplTest {
     boolean result = testObj.deleteAssessment(ASSESSMENT_ID);
 
     verify(assessmentRepositoryMock).delete(ASSESSMENT_ID);
-    Assert.assertTrue(result);
+    assertTrue(result);
   }
 
   @Test

--- a/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImplTest.java
+++ b/assessments-service/src/test/java/com/transformuk/hee/tis/assessment/service/service/impl/AssessmentServiceImplTest.java
@@ -105,7 +105,7 @@ public class AssessmentServiceImplTest {
 
     testObj = new AssessmentServiceImpl(assessmentRepositoryMock, assessmentMapper,
         new AssessmentListMapperImpl(), permissionServiceMock, assessmentDetailServiceMock,
-        assessmentOutcomeServiceMock, revalidationServiceMock);
+        assessmentOutcomeServiceMock, revalidationServiceMock, null);
 
     ReflectionTestUtils.setField(testObj, "assessmentService", testObj);
   }
@@ -695,7 +695,7 @@ public class AssessmentServiceImplTest {
 
     List<AssessmentDTO> assessmentDtos = Collections.singletonList(assessmentDto);
 
-    AssessmentDTO result = testObj.patchAssessments(assessmentDtos).get(0);
+    testObj.patchAssessments(assessmentDtos).get(0);
 
     verify(assessmentDetailServiceMock).create(any(Assessment.class),
         any(AssessmentDetailDTO.class));


### PR DESCRIPTION
1. remove` transational` annotation from bulk upload service method. This method accepts a list of entire spreadsheet, and it would be better not to be marked as `transactional`, otherwise, any exception could cause the entire rollback. Besides, we've already got those save/update methods in each service to be transactional, so I just remove it from this method.
2.  `AssessmentOutcomeSevice.save()` method throws an `IllegalStageException` when the outcome is marked as legacy, so added another catch block to give users more info on this.

Sonar prompted: methods with Spring proxy (@Async or @Transactional methods) should not be called via "this"
https://sonarcloud.io/organizations/health-education-england/rules?open=java%3AS6809&rule_key=java%3AS6809&tab=how_to_fix

TIS21-6825