### PR TITLE
fix: MySql compatibility

### DIFF
--- a/assessments-service/Dockerfile
+++ b/assessments-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM eclipse-temurin:11-alpine
 
 EXPOSE 8097
 

--- a/assessments-service/pom.xml
+++ b/assessments-service/pom.xml
@@ -270,6 +270,8 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
+      <!-- TODO: Remove when parent is upgraded -->
+      <version>8.0.27</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>


### PR DESCRIPTION
This minimises changes as required for progression of the Epic. Further upgrades, with a larger refactor would block this.

Run on a minimally different base image.

TIS21-8588: Make app suitable for new Amazon RDS